### PR TITLE
Fix path to elkjs

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -1,4 +1,4 @@
-const ELK = require('elkjs');
+const ELK = require('elkjs/lib/elk.bundled.js'');
 const elk = new ELK();
 const assign = require('./assign');
 const defaults = require('./defaults');


### PR DESCRIPTION
Currently this depends on the elkjs file that depends on `webworker-threads` which is not available in the browser.

They recommend instead depending on a pre-bundled version https://github.com/OpenKieler/elkjs/issues/68

This fixes https://github.com/jfstephe/cytoscape.js-elk/issues/13 and https://github.com/jfstephe/cytoscape.js-elk/issues/10

I have published a version of this package with this change, to use until a version is released here, in case anyone needs it: `cytoscape-elk-saul@1.1.12`.