### PR TITLE
CommonJS compatibility fixes

### DIFF
--- a/dist/cytoscape-elk.js
+++ b/dist/cytoscape-elk.js
@@ -7,7 +7,7 @@
 		exports["cytoscapeElk"] = factory(require("elkjs"));
 	else
 		root["cytoscapeElk"] = factory(root["ELK"]);
-})(self, function(__WEBPACK_EXTERNAL_MODULE__434__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE__434__) {
 return /******/ (function() { // webpackBootstrap
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({

--- a/dist/cytoscape-elk.js
+++ b/dist/cytoscape-elk.js
@@ -15,8 +15,6 @@ return /******/ (function() { // webpackBootstrap
 /***/ 466:
 /***/ (function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
-// ESM COMPAT FLAG
-__webpack_require__.r(__webpack_exports__);
 
 // EXPORTS
 __webpack_require__.d(__webpack_exports__, {
@@ -343,22 +341,11 @@ module.exports = __WEBPACK_EXTERNAL_MODULE__434__;
 /******/ 		__webpack_require__.o = function(obj, prop) { return Object.prototype.hasOwnProperty.call(obj, prop); }
 /******/ 	}();
 /******/ 	
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	!function() {
-/******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = function(exports) {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	}();
-/******/ 	
 /************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	return __webpack_require__(466);
 /******/ })()
-;
+.default;
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env, argv) => {
       filename: 'cytoscape-elk.js',
       library: 'cytoscapeElk',
       libraryTarget: 'umd',
+      globalObject: 'this',
     },
     module: {
       rules: [{ test: /\.js$/, exclude: /node_modules/, use: 'babel-loader' }],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env, argv) => {
       filename: 'cytoscape-elk.js',
       library: 'cytoscapeElk',
       libraryTarget: 'umd',
+      libraryExport: 'default',
       globalObject: 'this',
     },
     module: {


### PR DESCRIPTION
Fixes #25.

The Webpack upgrades in #15 had inadvertently broken both Node.js and CommonJS compatibility:

* The UMD root object was automatically set to `self`, which works in modern browsers but not in Node.js.
* The default export for the UMD module was an ES module object with a `default` property, so what previously had been just `require("cytoscape.js-elk")` had now to be `require("cytoscape.js-elk").default`. to access the default export (the ELK layout constructor).

👉  ⚠️  This should not break compatibility with bundling, though I did not have the opportunity to try that.