### PR TITLE
Make Room for Edge Labels

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -58,6 +58,11 @@ const makeEdge = function (edge /*, options*/) {
     source: edge.data('source'),
     target: edge.data('target'),
   };
+  
+  const label = edge.style("label");
+  if (label) {
+    k['labels'] = [{text: label}];
+  }
 
   edge.scratch('elk', k);
 


### PR DESCRIPTION
Previously, when I had edge labels, ELK would sometimes place the nodes too close together and the labels would overlap the nodes. By passing in the edge labels text to ELK, it makes room for them.