### PR TITLE
Move edges to child nodes

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -114,20 +114,19 @@ const makeGraph = function (nodes, edges, options) {
   for (let i = 0; i < elkEdges.length; i++) {
     const k = elkEdges[i];
 
-    // put all edges in the top level for now
     // TODO does this cause issues in certain edgecases?
-    /*let e = k._cyEle;
+    let e = k._cyEle;
     let parentSrc = e.source().parent();
     let parentTgt = e.target().parent();
-    if ( false && parentSrc.nonempty() && parentTgt.nonempty() && parentSrc.same( parentTgt ) ){
+    if ( parentSrc.nonempty() && parentTgt.nonempty() && parentSrc.same( parentTgt ) ){
       let kp = elkEleLookup[ parentSrc.id() ];
 
       kp.edges = kp.edges || [];
 
       kp.edges.push( k );
-    } else {*/
-    graph.edges.push(k);
-    //}
+    } else {
+      graph.edges.push(k);
+    }
   }
 
   return graph;


### PR DESCRIPTION
I noticed that currently, ELK will not make room for edges in compound nodes, because the edges exist on the parent. This change updates that, so that ELK will make room for the edges in a compound node.

However, I could not figure out a way to get it to make room for edges from inside a compound node to outside of it.