### PR TITLE
Support laying out children with parents

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -160,11 +160,9 @@ class Layout {
 
     const elk = new ELK();
     const graph = makeGraph(nodes, edges, options);
-
+    graph['layoutOptions'] = options.elk
     elk
-      .layout(graph, {
-        layoutOptions: options.elk,
-      })
+      .layout(graph)
       .then(() => {
         nodes
           .filter((n) => !n.isParent())


### PR DESCRIPTION
ELK recommends that you set `org.eclipse.elk.hierarchyHandling` to `INCLUDE_CHILDREN`, in order to lay out graphs that have edges between nodes inside compound nodes to other nodes.

Currently, if I do that, I get this error:

> Uncaught (in promise) Error: org.eclipse.elk.core.UnsupportedGraphException: The source or the target of edge ElkEdge "edge:96" ElkNode "1:8" (-30.5,-16 | 61,32) -> ElkNode "1:2" (-27,-16 | 54,32) could not be found. This usually happens when an edge connects a node laid out by ELK Layered to a node in another level of hierarchy laid out by either another instance of ELK Layered or another layout algorithm alltogether. The former can be solved by setting the hierarchyHandling option to INCLUDE_CHILDREN.

However, I noticed that if instead of passing in the options as an argument to the layout algorithm, I set them on the graph, then it seems to work fine.

This PR supersedes #31 to support layouts with these complex edges. That PR moved the edges inside the parents, which worked to properly layout graphs inside the compound nodes, but didn't layout with regard to edges from inside to outside. Using the `INCLUDE_CHILDREN` option along with this PR gives me a proper total layout.

# Example

Here is an example of a large graph ([gist](https://gist.github.com/saulshanabrook/ab026624c005dc68b3232278f363a80f) with data and options) with the different options:


## Status Quo

With the default options, and the layered algorithm, all the edges inside the compound nodes are ignored when calculating the layout, along with the edges from outside to inside the compound nodes

<img width="1234" alt="Screen Shot 2021-06-25 at 10 47 44 AM" src="https://user-images.githubusercontent.com/1186124/123442580-04180280-d5a3-11eb-98f2-8893378dbfd9.png">

## Moving edges inside compound nodes, https://github.com/cytoscape/cytoscape.js-elk/pull/31

If instead, we use #31 to move the edges inside the compound nodes, then you see that those compound nodes are laid out properly. However, it still doesn't take into account edges from outside to inside the compound nodes. 

<img width="1232" alt="Screen Shot 2021-06-25 at 10 51 10 AM" src="https://user-images.githubusercontent.com/1186124/123442813-46d9da80-d5a3-11eb-9933-70e54dfb8ed6.png">

## `INCLUDE_CHILDREN` with this PR

If we use this PR and set the `org.eclipse.elk.hierarchyHandling` option to `INCLUDE_CHILDREN`, then the compound nodes are laid out properly internally as well as being properly laid out with regards to edges from the parent environment. 

<img width="1239" alt="Screen Shot 2021-06-25 at 10 53 51 AM" src="https://user-images.githubusercontent.com/1186124/123443164-a3d59080-d5a3-11eb-8188-8af649b6b749.png">


