### PR TITLE
Add support for per node layout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ var options = {
 cy.layout( options ).run();
 ```
 
+You can set layout options per node by adding a `layoutOptions` key to the data of the node. This is useful for tweaking the layout of a particular node, like for [setting its partition](https://www.eclipse.org/elk/reference/options/org-eclipse-elk-partitioning-partition.html) for the layered layout
+
 The set of  `options.elk.algorithm` values that are supported by ELK.js follows:
 
 - `box` : ([Demo](https://cytoscape.github.io/cytoscape.js-elk/?demo=box)) ([Docs](https://www.eclipse.org/elk/reference/algorithms/org-eclipse-elk-box.html)) Pack the nodes like boxes.

--- a/src/layout.js
+++ b/src/layout.js
@@ -32,6 +32,7 @@ const makeNode = function (node, options) {
   const k = {
     _cyEle: node,
     id: node.id(),
+    layoutOptions: node.data('layoutOptions')
   };
 
   if (!node.isParent()) {


### PR DESCRIPTION
This adds support for setting layout options per node. They are copied from the `layoutOptions` key in the data.

This is useful for setting options like the partition (https://www.eclipse.org/elk/reference/options/org-eclipse-elk-partitioning-partition.html) which are meant to be set per node, to customize how each node is laid out.

If the layoutOptions is not set in the data, it will just be set to undefined to retain the status quo behavior.