### PR TITLE
Add opt-in ELK edge geometry support for separated routed edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ var options = {
   ready: undefined, // Callback on layoutready
   stop: undefined, // Callback on layoutstop
   nodeLayoutOptions: undefined, // Per-node options function
+  useElkEdgeGeometry: false, // Whether to apply ELK edge routes to Cytoscape segment geometry
   elk: {
     // All options are available at http://www.eclipse.org/elk/reference.html
     //
@@ -85,6 +86,21 @@ var options = {
 };
 
 cy.layout( options ).run();
+```
+
+If you want ELK to provide routed edge geometry (e.g. to separate parallel edges in layered layouts), set `useElkEdgeGeometry: true`.
+When enabled, ELK `sections` points are translated into Cytoscape `segments` control data per edge.
+
+```js
+var options = {
+  name: 'elk',
+  useElkEdgeGeometry: true,
+  elk: {
+    algorithm: 'layered',
+    'elk.direction': 'RIGHT',
+    'elk.edgeRouting': 'ORTHOGONAL',
+  },
+};
 ```
 
 You can set layout options per node by defining a `nodeLayoutOptions` function which is called on a per-node basis. This is useful for tweaking the layout of a particular node, like for [setting its partition](https://www.eclipse.org/elk/reference/options/org-eclipse-elk-partitioning-partition.html) for the layered layout.

--- a/demo/demo-separated.js
+++ b/demo/demo-separated.js
@@ -1,0 +1,22 @@
+cytoscape({
+  container: document.getElementById('cy'),
+  elements: fetch('example-graphs/planar-chain.json').then((res) => res.json()),
+  layout: {
+    name: 'elk',
+    useElkEdgeGeometry: true,
+    elk: {
+      algorithm: 'layered',
+      'elk.direction': 'RIGHT',
+      'elk.edgeRouting': 'ORTHOGONAL',
+    },
+  },
+  style: [
+    {
+      selector: 'edge',
+      style: {
+        'target-arrow-shape': 'triangle',
+        'arrow-scale': 0.66,
+      },
+    },
+  ],
+});

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -6,6 +6,7 @@ const demos = [
   'layered',
   'mrtree',
   'random',
+  'separated',
   'stress',
 ];
 

--- a/dist/cytoscape-elk.js
+++ b/dist/cytoscape-elk.js
@@ -7,15 +7,15 @@
 		exports["cytoscapeElk"] = factory(require("elkjs/lib/elk.bundled.js"));
 	else
 		root["cytoscapeElk"] = factory(root["ELK"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE__632__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE__883__) {
 return /******/ (function() { // webpackBootstrap
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 632:
+/***/ 883:
 /***/ (function(module) {
 
-module.exports = __WEBPACK_EXTERNAL_MODULE__632__;
+module.exports = __WEBPACK_EXTERNAL_MODULE__883__;
 
 /***/ })
 
@@ -77,8 +77,6 @@ module.exports = __WEBPACK_EXTERNAL_MODULE__632__;
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
-!function() {
 
 // EXPORTS
 __webpack_require__.d(__webpack_exports__, {
@@ -86,15 +84,15 @@ __webpack_require__.d(__webpack_exports__, {
 });
 
 // EXTERNAL MODULE: external {"commonjs":"elkjs/lib/elk.bundled.js","commonjs2":"elkjs/lib/elk.bundled.js","amd":"elkjs","root":"ELK"}
-var elk_bundled_js_amd_elkjs_root_ELK_ = __webpack_require__(632);
+var elk_bundled_js_amd_elkjs_root_ELK_ = __webpack_require__(883);
 var elk_bundled_js_amd_elkjs_root_ELK_default = /*#__PURE__*/__webpack_require__.n(elk_bundled_js_amd_elkjs_root_ELK_);
-;// CONCATENATED MODULE: ./src/assign.js
+;// ./src/assign.js
 // Simple, internal Object.assign() polyfill for options objects etc.
+
 function assign_assign(tgt) {
   for (var _len = arguments.length, srcs = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
     srcs[_key - 1] = arguments[_key];
   }
-
   srcs.forEach(function (src) {
     Object.keys(src).forEach(function (k) {
       return tgt[k] = src[k];
@@ -102,9 +100,8 @@ function assign_assign(tgt) {
   });
   return tgt;
 }
-
 /* harmony default export */ var src_assign = (Object.assign != null ? Object.assign.bind(Object) : assign_assign);
-;// CONCATENATED MODULE: ./src/defaults.js
+;// ./src/defaults.js
 var defaults = {
   nodeDimensionsIncludeLabels: false,
   // Boolean which changes whether label dimensions are included when calculating node dimensions
@@ -132,6 +129,8 @@ var defaults = {
   // Callback on layoutstop
   nodeLayoutOptions: undefined,
   // Special options for only the nodes
+  useElkEdgeGeometry: false,
+  // Whether to apply ELK edge routes (sections) to Cytoscape segment geometry
   elk: {
     // Options to pass directly to ELK `layoutOptions`. The subsequent identifier has to be used as property key in quotes.
     // E.g. for 'org.eclipse.elk.direction' use:
@@ -144,21 +143,27 @@ var defaults = {
   priority: function priority() {
     return null;
   } // Edges with a non-nil value are skipped when geedy edge cycle breaking is enabled
-
 };
 /* harmony default export */ var src_defaults = (defaults);
-;// CONCATENATED MODULE: ./src/layout.js
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-
+;// ./src/layout.js
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+function _classCallCheck(a, n) { if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function"); }
+function _defineProperties(e, r) { for (var t = 0; t < r.length; t++) { var o = r[t]; o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o); } }
+function _createClass(e, r, t) { return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", { writable: !1 }), e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _slicedToArray(r, e) { return _arrayWithHoles(r) || _iterableToArrayLimit(r, e) || _unsupportedIterableToArray(r, e) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
+function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
 
 
 
 var elkOverrides = {};
-
+var minSegmentWeight = 0.01;
+var maxSegmentWeight = 0.99;
 var getPos = function getPos(ele, options) {
   var dims = ele.layoutDimensions(options);
   var parent = ele.parent();
@@ -167,48 +172,43 @@ var getPos = function getPos(ele, options) {
     x: k.x,
     y: k.y
   };
-
   while (parent.nonempty()) {
     var kp = parent.scratch('elk');
     p.x += kp.x;
     p.y += kp.y;
     parent = parent.parent();
-  } // elk considers a node position to be its top-left corner, while cy is the centre
+  }
 
-
+  // elk considers a node position to be its top-left corner, while cy is the centre
   p.x += dims.w / 2;
   p.y += dims.h / 2;
   return p;
 };
-
 var makeNode = function makeNode(node, options) {
   var k = {
     _cyEle: node,
     id: node.id()
-  }; // Apply nodeLayoutOptions per user-specified function
-  // e.g. nodeLayoutOptions => n.scratch('layoutOptions')
+  };
 
+  // Apply nodeLayoutOptions per user-specified function
+  // e.g. nodeLayoutOptions => n.scratch('layoutOptions')
   if (options.nodeLayoutOptions) {
     k.layoutOptions = options.nodeLayoutOptions(node);
   }
-
   if (!node.isParent()) {
     var dims = node.layoutDimensions(options);
-    var p = node.position(); // the elk position is the top-left corner, cy is the centre
+    var p = node.position();
 
+    // the elk position is the top-left corner, cy is the centre
     k.x = p.x - dims.w / 2;
     k.y = p.y - dims.h / 2;
     k.width = dims.w;
     k.height = dims.h;
   }
-
   node.scratch('elk', k);
   return k;
 };
-
-var makeEdge = function makeEdge(edge
-/*, options*/
-) {
+var makeEdge = function makeEdge(edge /*, options*/) {
   var k = {
     _cyEle: edge,
     id: edge.id(),
@@ -218,7 +218,79 @@ var makeEdge = function makeEdge(edge
   edge.scratch('elk', k);
   return k;
 };
-
+var getElkEdgePoints = function getElkEdgePoints(elkEdge) {
+  var sec = elkEdge.sections && elkEdge.sections[0];
+  if (!sec || !sec.startPoint || !sec.endPoint) {
+    return [];
+  }
+  var points = [sec.startPoint];
+  var bends = sec.bendPoints || [];
+  for (var i = 0; i < bends.length; i++) {
+    points.push(bends[i]);
+  }
+  points.push(sec.endPoint);
+  return points;
+};
+var fmtEndpoint = function fmtEndpoint(dx, dy) {
+  return "".concat(dx.toFixed(1), "px ").concat(dy.toFixed(1), "px");
+};
+var projectOntoLine = function projectOntoLine(a, b, p) {
+  var dx = b.x - a.x;
+  var dy = b.y - a.y;
+  var len2 = dx * dx + dy * dy;
+  if (len2 < 0.001) {
+    return {
+      w: 0.5,
+      d: 0
+    };
+  }
+  var w = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  var cross = dx * (p.y - a.y) - dy * (p.x - a.x);
+  var d = cross / Math.sqrt(len2);
+  return {
+    w: w,
+    d: d
+  };
+};
+var applyElkEdgeGeometry = function applyElkEdgeGeometry(edge, elkEdge, sourceCenter, targetCenter) {
+  var points = getElkEdgePoints(elkEdge);
+  if (points.length < 2) {
+    return;
+  }
+  var _points = _slicedToArray(points, 1),
+    startPoint = _points[0];
+  var endPoint = points[points.length - 1];
+  var bends = points.slice(1, points.length - 1);
+  var sourceEndpoint = fmtEndpoint(startPoint.x - sourceCenter.x, startPoint.y - sourceCenter.y);
+  var targetEndpoint = fmtEndpoint(endPoint.x - targetCenter.x, endPoint.y - targetCenter.y);
+  if (bends.length === 0) {
+    edge.style({
+      'curve-style': 'segments',
+      'edge-distances': 'endpoints',
+      'source-endpoint': sourceEndpoint,
+      'target-endpoint': targetEndpoint,
+      'segment-weights': '0.5',
+      'segment-distances': '0'
+    });
+    return;
+  }
+  var segmentWeights = [];
+  var segmentDistances = [];
+  for (var i = 0; i < bends.length; i++) {
+    var proj = projectOntoLine(startPoint, endPoint, bends[i]);
+    var weight = Math.max(minSegmentWeight, Math.min(maxSegmentWeight, proj.w));
+    segmentWeights.push(weight.toFixed(4));
+    segmentDistances.push(proj.d.toFixed(2));
+  }
+  edge.style({
+    'curve-style': 'segments',
+    'edge-distances': 'endpoints',
+    'source-endpoint': sourceEndpoint,
+    'target-endpoint': targetEndpoint,
+    'segment-weights': segmentWeights.join(' '),
+    'segment-distances': segmentDistances.join(' ')
+  });
+};
 var makeGraph = function makeGraph(nodes, edges, options) {
   var elkNodes = [];
   var elkEdges = [];
@@ -227,64 +299,58 @@ var makeGraph = function makeGraph(nodes, edges, options) {
     id: 'root',
     children: [],
     edges: []
-  }; // map all nodes
+  };
 
+  // map all nodes
   for (var i = 0; i < nodes.length; i++) {
     var n = nodes[i];
     var k = makeNode(n, options);
     elkNodes.push(k);
     elkEleLookup[n.id()] = k;
-  } // map all edges
+  }
 
-
+  // map all edges
   for (var _i = 0; _i < edges.length; _i++) {
     var e = edges[_i];
-
     var _k = makeEdge(e, options);
-
     elkEdges.push(_k);
     elkEleLookup[e.id()] = _k;
-  } // make hierarchy
+  }
 
-
+  // make hierarchy
   for (var _i2 = 0; _i2 < elkNodes.length; _i2++) {
     var _k2 = elkNodes[_i2];
     var _n = _k2._cyEle;
-
     if (!_n.isChild()) {
       graph.children.push(_k2);
     } else {
       var parent = _n.parent();
-
       var parentK = elkEleLookup[parent.id()];
       var children = parentK.children = parentK.children || [];
       children.push(_k2);
     }
   }
-
   for (var _i3 = 0; _i3 < elkEdges.length; _i3++) {
-    var _k3 = elkEdges[_i3]; // put all edges in the top level for now
-    // TODO does this cause issues in certain edgecases?
+    var _k3 = elkEdges[_i3];
 
+    // put all edges in the top level for now
+    // TODO does this cause issues in certain edgecases?
     /*let e = k._cyEle;
     let parentSrc = e.source().parent();
     let parentTgt = e.target().parent();
     if ( false && parentSrc.nonempty() && parentTgt.nonempty() && parentSrc.same( parentTgt ) ){
       let kp = elkEleLookup[ parentSrc.id() ];
-       kp.edges = kp.edges || [];
-       kp.edges.push( k );
+        kp.edges = kp.edges || [];
+        kp.edges.push( k );
     } else {*/
-
-    graph.edges.push(_k3); //}
+    graph.edges.push(_k3);
+    //}
   }
-
   return graph;
 };
-
 var Layout = /*#__PURE__*/function () {
   function Layout(options) {
     _classCallCheck(this, Layout);
-
     var elkOptions = options.elk;
     var cy = options.cy;
     this.options = src_assign({}, src_defaults, options);
@@ -292,8 +358,7 @@ var Layout = /*#__PURE__*/function () {
       aspectRatio: cy.width() / cy.height()
     }, src_defaults.elk, elkOptions, elkOverrides);
   }
-
-  _createClass(Layout, [{
+  return _createClass(Layout, [{
     key: "run",
     value: function run() {
       var layout = this;
@@ -305,6 +370,27 @@ var Layout = /*#__PURE__*/function () {
       var graph = makeGraph(nodes, edges, options);
       graph['layoutOptions'] = options.elk;
       elk.layout(graph).then(function () {
+        var nodePosLookup = {};
+        nodes.filter(function (n) {
+          return !n.isParent();
+        }).forEach(function (n) {
+          nodePosLookup[n.id()] = getPos(n, options);
+        });
+        if (options.useElkEdgeGeometry) {
+          var elkEdgeLookup = {};
+          for (var i = 0; i < graph.edges.length; i++) {
+            elkEdgeLookup[graph.edges[i].id] = graph.edges[i];
+          }
+          edges.forEach(function (edge) {
+            var elkEdge = elkEdgeLookup[edge.id()];
+            var sourcePos = nodePosLookup[edge.source().id()];
+            var targetPos = nodePosLookup[edge.target().id()];
+            if (!elkEdge || !sourcePos || !targetPos) {
+              return;
+            }
+            applyElkEdgeGeometry(edge, elkEdge, sourcePos, targetPos);
+          });
+        }
         nodes.filter(function (n) {
           return !n.isParent();
         }).layoutPositions(layout, options, function (n) {
@@ -324,31 +410,25 @@ var Layout = /*#__PURE__*/function () {
       return this; // chaining
     }
   }]);
-
-  return Layout;
 }();
-
 /* harmony default export */ var layout = (Layout);
-;// CONCATENATED MODULE: ./src/index.js
- // registers the extension on a cytoscape lib ref
+;// ./src/index.js
 
+
+// registers the extension on a cytoscape lib ref
 var register = function register(cytoscape) {
   if (!cytoscape) {
     return;
   } // can't register if cytoscape unspecified
 
-
   cytoscape('layout', 'elk', layout); // register with cytoscape.js
 };
-
 if (typeof cytoscape !== 'undefined') {
   // expose to global cytoscape (i.e. window.cytoscape)
   // eslint-disable-next-line no-undef
   register(cytoscape);
 }
-
 /* harmony default export */ var src = (register);
-}();
 __webpack_exports__ = __webpack_exports__["default"];
 /******/ 	return __webpack_exports__;
 /******/ })()

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -14,6 +14,7 @@ const defaults = {
   ready: undefined, // Callback on layoutready
   stop: undefined, // Callback on layoutstop
   nodeLayoutOptions: undefined, // Special options for only the nodes
+  useElkEdgeGeometry: false, // Whether to apply ELK edge routes (sections) to Cytoscape segment geometry
   elk: {
     // Options to pass directly to ELK `layoutOptions`. The subsequent identifier has to be used as property key in quotes.
     // E.g. for 'org.eclipse.elk.direction' use:

--- a/src/layout.js
+++ b/src/layout.js
@@ -3,6 +3,8 @@ import assign from './assign';
 import defaults from './defaults';
 
 const elkOverrides = {};
+const minSegmentWeight = 0.01;
+const maxSegmentWeight = 0.99;
 
 const getPos = function (ele, options) {
   const dims = ele.layoutDimensions(options);
@@ -36,11 +38,9 @@ const makeNode = function (node, options) {
 
   // Apply nodeLayoutOptions per user-specified function
   // e.g. nodeLayoutOptions => n.scratch('layoutOptions')
-  if (options.nodeLayoutOptions){
+  if (options.nodeLayoutOptions) {
     k.layoutOptions = options.nodeLayoutOptions(node);
   }
-
-
 
   if (!node.isParent()) {
     const dims = node.layoutDimensions(options);
@@ -70,6 +70,105 @@ const makeEdge = function (edge /*, options*/) {
   edge.scratch('elk', k);
 
   return k;
+};
+
+const getElkEdgePoints = function (elkEdge) {
+  const sec = elkEdge.sections && elkEdge.sections[0];
+
+  if (!sec || !sec.startPoint || !sec.endPoint) {
+    return [];
+  }
+
+  const points = [sec.startPoint];
+  const bends = sec.bendPoints || [];
+
+  for (let i = 0; i < bends.length; i++) {
+    points.push(bends[i]);
+  }
+
+  points.push(sec.endPoint);
+
+  return points;
+};
+
+const fmtEndpoint = function (dx, dy) {
+  return `${dx.toFixed(1)}px ${dy.toFixed(1)}px`;
+};
+
+const projectOntoLine = function (a, b, p) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len2 = dx * dx + dy * dy;
+
+  if (len2 < 0.001) {
+    return {
+      w: 0.5,
+      d: 0,
+    };
+  }
+
+  const w = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  const cross = dx * (p.y - a.y) - dy * (p.x - a.x);
+  const d = cross / Math.sqrt(len2);
+
+  return {
+    w,
+    d,
+  };
+};
+
+const applyElkEdgeGeometry = function (edge, elkEdge, sourceCenter, targetCenter) {
+  const points = getElkEdgePoints(elkEdge);
+
+  if (points.length < 2) {
+    return;
+  }
+
+  const [startPoint] = points;
+  const endPoint = points[points.length - 1];
+  const bends = points.slice(1, points.length - 1);
+
+  const sourceEndpoint = fmtEndpoint(
+    startPoint.x - sourceCenter.x,
+    startPoint.y - sourceCenter.y
+  );
+  const targetEndpoint = fmtEndpoint(
+    endPoint.x - targetCenter.x,
+    endPoint.y - targetCenter.y
+  );
+
+  if (bends.length === 0) {
+    edge.style({
+      'curve-style': 'segments',
+      'edge-distances': 'endpoints',
+      'source-endpoint': sourceEndpoint,
+      'target-endpoint': targetEndpoint,
+      'segment-weights': '0.5',
+      'segment-distances': '0',
+    });
+
+    return;
+  }
+
+  const segmentWeights = [];
+  const segmentDistances = [];
+
+  for (let i = 0; i < bends.length; i++) {
+    const proj = projectOntoLine(startPoint, endPoint, bends[i]);
+    const weight = Math.max(minSegmentWeight, Math.min(maxSegmentWeight, proj.w));
+
+    segmentWeights.push(weight.toFixed(4));
+    segmentDistances.push(proj.d.toFixed(2));
+  }
+
+  edge.style({
+    'curve-style': 'segments',
+    'edge-distances': 'endpoints',
+    'source-endpoint': sourceEndpoint,
+    'target-endpoint': targetEndpoint,
+    'segment-weights': segmentWeights.join(' '),
+    'segment-distances': segmentDistances.join(' '),
+  });
 };
 
 const makeGraph = function (nodes, edges, options) {
@@ -169,9 +268,38 @@ class Layout {
     const elk = new ELK();
     const graph = makeGraph(nodes, edges, options);
     graph['layoutOptions'] = options.elk;
+
     elk
       .layout(graph)
       .then(() => {
+        const nodePosLookup = {};
+
+        nodes
+          .filter((n) => !n.isParent())
+          .forEach((n) => {
+            nodePosLookup[n.id()] = getPos(n, options);
+          });
+
+        if (options.useElkEdgeGeometry) {
+          const elkEdgeLookup = {};
+
+          for (let i = 0; i < graph.edges.length; i++) {
+            elkEdgeLookup[graph.edges[i].id] = graph.edges[i];
+          }
+
+          edges.forEach((edge) => {
+            const elkEdge = elkEdgeLookup[edge.id()];
+            const sourcePos = nodePosLookup[edge.source().id()];
+            const targetPos = nodePosLookup[edge.target().id()];
+
+            if (!elkEdge || !sourcePos || !targetPos) {
+              return;
+            }
+
+            applyElkEdgeGeometry(edge, elkEdge, sourcePos, targetPos);
+          });
+        }
+
         nodes
           .filter((n) => !n.isParent())
           .layoutPositions(layout, options, (n) => getPos(n, options));


### PR DESCRIPTION
## Summary

This PR adds an opt-in feature to apply ELK edge section geometry to Cytoscape edges, so routed edges can remain visually separated instead of collapsing into overlapping paths.

## Context

This change addresses the behavior discussed in:

- https://github.com/cytoscape/cytoscape.js-elk/issues/47
- https://stackoverflow.com/questions/66786313/keep-edges-seperated

## What changed

- Added a new layout option: useElkEdgeGeometry (default: false).
- When enabled, ELK section points (startPoint, bendPoints, endPoint) are translated into Cytoscape segment styles per edge:
  - curve-style: segments
  - edge-distances: endpoints
  - source-endpoint and target-endpoint
  - segment-weights and segment-distances
- Added weight clamping to avoid invalid endpoint warnings on extreme projections.
- Added a dedicated demo named separated.
- Updated README with usage and example configuration.

## Backward compatibility

- Existing behavior is unchanged by default.
- The feature is strictly opt-in via useElkEdgeGeometry.

## Validation

- Lint passed.
- Build passed.
- Manual verification passed in the separated demo.

## Files changed

- defaults.js
- layout.js
- demo.js
- demo-separated.js
- README.md
- cytoscape-elk.js

## Screenshot

Added a screenshot from the separated demo output.
<img width="1009" height="472" alt="image" src="https://github.com/user-attachments/assets/21b8747b-4420-4bdf-9aa3-238490a3986f" />
